### PR TITLE
Add vibe typer link

### DIFF
--- a/src/components/ControlsPanel/ControlsPanel.tsx
+++ b/src/components/ControlsPanel/ControlsPanel.tsx
@@ -127,14 +127,21 @@ export function ControlsPanel({
               >
                 Greg Kamradt
               </a>
-              {' '}• 
-              <a 
-                href="https://github.com/gkamradt/MultiTerminalCodeViz" 
-                target="_blank" 
+              {' '}•
+              <a
+                href="https://github.com/gkamradt/MultiTerminalCodeViz"
+                target="_blank"
                 rel="noopener noreferrer"
                 className="text-blue-400 hover:text-blue-300 transition-colors underline"
               >
                 Code
+              </a>
+              {' '}•
+              <a
+                href="/typer"
+                className="text-blue-400 hover:text-blue-300 transition-colors underline"
+              >
+                use the vibe typer
               </a>
             </p>
           </div>

--- a/src/components/ControlsPanel/__tests__/ControlsPanel.test.tsx
+++ b/src/components/ControlsPanel/__tests__/ControlsPanel.test.tsx
@@ -32,6 +32,7 @@ describe('ControlsPanel', () => {
     expect(screen.getByText('Arrange')).toBeInTheDocument();
     expect(screen.getByText(/Theme:/)).toBeInTheDocument();
     expect(screen.getByText(/Made with ❤️ by/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /use the vibe typer/i })).toBeInTheDocument();
   });
 
   it('should call onTerminalCountChange when + button is clicked', () => {


### PR DESCRIPTION
## Summary
- add link to Vibe Typer in controls footer
- test for the new link

## Testing
- `npx vitest run --silent`

------
https://chatgpt.com/codex/tasks/task_e_684d92318f34832da461315f9c53fcdc