### PR TITLE
Fix vertical scroll on /typer

### DIFF
--- a/src/pages/AsciiTyper.tsx
+++ b/src/pages/AsciiTyper.tsx
@@ -74,8 +74,8 @@ export function AsciiTyper() {
   };
 
   return (
-    <div 
-      className="min-h-screen p-8 transition-colors duration-300"
+    <div
+      className="h-screen overflow-y-auto p-8 transition-colors duration-300"
       style={{ backgroundColor }}
     >
       <div className="max-w-6xl mx-auto">


### PR DESCRIPTION
## Summary
- allow scrolling inside the ASCII typer page so content fits on mobile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d99ee47d8832d86e8bd4f4931a4ee